### PR TITLE
Fix numerous TypeScript type errors across the codebase.

### DIFF
--- a/src/components/DemoPOSInterface.tsx
+++ b/src/components/DemoPOSInterface.tsx
@@ -32,6 +32,7 @@ import {
   getDeviceOptimizations,
   responsiveFont,
   responsiveSpacing,
+  scaleSpacing,
   wp,
   hp,
   getGridColumns,

--- a/src/services/AnalyticsService.ts
+++ b/src/services/AnalyticsService.ts
@@ -809,3 +809,4 @@ class AnalyticsService implements IAnalyticsService {
 // Export singleton instance
 export const analyticsService = AnalyticsService.getInstance();
 export { AnalyticsService };
+export type { ProductAnalytics, DailySummary, TimeRangeAnalytics };

--- a/src/services/BusinessConfigService.ts
+++ b/src/services/BusinessConfigService.ts
@@ -1,9 +1,9 @@
 import { BusinessInfo, DocumentSettings } from '../types/documents';
-import { StorageService } from './StorageService';
+import { storageService } from './StorageService';
 
 export class BusinessConfigService {
   private static instance: BusinessConfigService;
-  private storage: StorageService;
+  private storage: typeof storageService;
   private readonly BUSINESS_INFO_KEY = 'business_info';
   private readonly DOCUMENT_SETTINGS_KEY = 'document_settings';
 

--- a/src/services/CloudBackupService.ts
+++ b/src/services/CloudBackupService.ts
@@ -5,7 +5,7 @@ import {
   CloudRestoreInfo,
   CloudError
 } from '../types/Cloud';
-import { StorageService } from './StorageService';
+import { storageService } from './StorageService';
 import { productService } from './ProductService';
 import { salesService } from './SimpleSalesService';
 import { authService } from './AuthService';
@@ -265,7 +265,7 @@ class CloudBackupService implements ICloudBackupService {
         
         for (const product of data.data.products) {
           try {
-            await productService.addProduct(product);
+            await productService.createProduct(product);
             restoreInfo.entitiesRestored.products++;
           } catch (error) {
             console.warn(`Failed to restore product ${product.id}:`, error);

--- a/src/services/CloudSyncService.ts
+++ b/src/services/CloudSyncService.ts
@@ -12,7 +12,7 @@ import {
   ConflictError
 } from '../types/Cloud';
 import { cloudNetworkService } from './CloudNetworkService';
-import { StorageService } from './StorageService';
+import { storageService } from './StorageService';
 
 class CloudSyncService implements ICloudSyncService {
   private static instance: CloudSyncService;
@@ -433,6 +433,10 @@ class CloudSyncService implements ICloudSyncService {
     console.log(`🔀 Resolving conflict for ${conflict.entityType}:${conflict.entityId}`);
     
     try {
+      // Mark conflict as resolved
+      conflict.resolvedAt = new Date().toISOString();
+      conflict.autoResolved = conflict.resolution !== 'manual';
+
       // Apply the conflict resolution
       switch (conflict.resolution) {
         case 'use_local':
@@ -470,10 +474,6 @@ class CloudSyncService implements ICloudSyncService {
           console.log('⏳ Manual conflict resolution required');
           return;
       }
-      
-      // Mark conflict as resolved
-      conflict.resolvedAt = new Date().toISOString();
-      conflict.autoResolved = conflict.resolution !== 'manual';
       
       this.syncStats.conflictsResolved++;
       await this.saveSyncData();

--- a/src/services/DocumentService.ts
+++ b/src/services/DocumentService.ts
@@ -14,11 +14,11 @@ import {
 } from '../types/documents';
 import { Sale, CartItem } from '../services/SimpleSalesService';
 import { businessConfigService } from './BusinessConfigService';
-import { StorageService } from './StorageService';
+import { storageService } from './StorageService';
 
 export class DocumentService {
   private static instance: DocumentService;
-  private storage: StorageService;
+  private storage: typeof storageService;
   private readonly RECEIPTS_KEY = 'receipts_';
   private readonly INVOICES_KEY = 'invoices_';
   private readonly TEMPLATES_KEY = 'document_templates';

--- a/src/services/SeedDataService.ts
+++ b/src/services/SeedDataService.ts
@@ -138,7 +138,7 @@ export class SeedDataService {
       console.log('🌱 Seeding sample products...');
       
       for (const productData of sampleProducts) {
-        await productService.addProduct(productData);
+        await productService.createProduct(productData);
       }
 
       console.log(`✅ Successfully seeded ${sampleProducts.length} sample products!`);
@@ -232,7 +232,7 @@ export class SeedDataService {
       barcode: `TEST${Date.now()}`,
     };
 
-    return await productService.addProduct(productData);
+    return await productService.createProduct(productData);
   }
 }
 

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -64,6 +64,6 @@ export const theme = {
     medium: 300,
     slow: 500,
   },
-};
+} as const;
 
 export type Theme = typeof theme;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -8,6 +8,7 @@ export interface Product {
   cost: number;
   stock_qty: number;
   tax_rate: number;
+  category?: string;
 }
 
 export interface Sale {
@@ -42,6 +43,7 @@ export interface CreateProductInput {
   cost: number;
   stock_qty?: number;
   tax_rate?: number;
+  category?: string;
 }
 
 export interface UpdateProductInput {
@@ -52,6 +54,7 @@ export interface UpdateProductInput {
   cost?: number;
   stock_qty?: number;
   tax_rate?: number;
+  category?: string;
 }
 
 export interface CreateSaleInput {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4714,6 +4714,11 @@ fs.realpath@^1.0.0:
   resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
+fsevents@^2.3.2:
+  version "2.3.3"
+  resolved "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz"
+  integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
+
 function-bind@^1.1.2:
   version "1.1.2"
   resolved "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz"
@@ -6128,6 +6133,51 @@ lighthouse-logger@^1.0.0:
   dependencies:
     debug "^2.6.9"
     marky "^1.2.2"
+
+lightningcss-darwin-arm64@1.27.0:
+  version "1.27.0"
+  resolved "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.27.0.tgz"
+  integrity sha512-Gl/lqIXY+d+ySmMbgDf0pgaWSqrWYxVHoc88q+Vhf2YNzZ8DwoRzGt5NZDVqqIW5ScpSnmmjcgXP87Dn2ylSSQ==
+
+lightningcss-darwin-x64@1.27.0:
+  version "1.27.0"
+  resolved "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.27.0.tgz"
+  integrity sha512-0+mZa54IlcNAoQS9E0+niovhyjjQWEMrwW0p2sSdLRhLDc8LMQ/b67z7+B5q4VmjYCMSfnFi3djAAQFIDuj/Tg==
+
+lightningcss-freebsd-x64@1.27.0:
+  version "1.27.0"
+  resolved "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.27.0.tgz"
+  integrity sha512-n1sEf85fePoU2aDN2PzYjoI8gbBqnmLGEhKq7q0DKLj0UTVmOTwDC7PtLcy/zFxzASTSBlVQYJUhwIStQMIpRA==
+
+lightningcss-linux-arm-gnueabihf@1.27.0:
+  version "1.27.0"
+  resolved "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.27.0.tgz"
+  integrity sha512-MUMRmtdRkOkd5z3h986HOuNBD1c2lq2BSQA1Jg88d9I7bmPGx08bwGcnB75dvr17CwxjxD6XPi3Qh8ArmKFqCA==
+
+lightningcss-linux-arm64-gnu@1.27.0:
+  version "1.27.0"
+  resolved "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.27.0.tgz"
+  integrity sha512-cPsxo1QEWq2sfKkSq2Bq5feQDHdUEwgtA9KaB27J5AX22+l4l0ptgjMZZtYtUnteBofjee+0oW1wQ1guv04a7A==
+
+lightningcss-linux-arm64-musl@1.27.0:
+  version "1.27.0"
+  resolved "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.27.0.tgz"
+  integrity sha512-rCGBm2ax7kQ9pBSeITfCW9XSVF69VX+fm5DIpvDZQl4NnQoMQyRwhZQm9pd59m8leZ1IesRqWk2v/DntMo26lg==
+
+lightningcss-linux-x64-gnu@1.27.0:
+  version "1.27.0"
+  resolved "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.27.0.tgz"
+  integrity sha512-Dk/jovSI7qqhJDiUibvaikNKI2x6kWPN79AQiD/E/KeQWMjdGe9kw51RAgoWFDi0coP4jinaH14Nrt/J8z3U4A==
+
+lightningcss-linux-x64-musl@1.27.0:
+  version "1.27.0"
+  resolved "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.27.0.tgz"
+  integrity sha512-QKjTxXm8A9s6v9Tg3Fk0gscCQA1t/HMoF7Woy1u68wCk5kS4fR+q3vXa1p3++REW784cRAtkYKrPy6JKibrEZA==
+
+lightningcss-win32-arm64-msvc@1.27.0:
+  version "1.27.0"
+  resolved "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.27.0.tgz"
+  integrity sha512-/wXegPS1hnhkeG4OXQKEMQeJd48RDC3qdh+OA8pCuOPCyvnm/yEayrJdJVqzBsqpy1aJklRCVxscpFur80o6iQ==
 
 lightningcss-win32-x64-msvc@1.27.0:
   version "1.27.0"


### PR DESCRIPTION
This commit addresses a large number of TypeScript errors by fixing type definitions, imports, and incorrect method calls.

Key changes:
- Corrected `fontWeight` type inference in the theme by using `as const`.
- Added missing `scaleSpacing` import to components.
- Added `category` property to the `Product` type and related interfaces.
- Fixed an issue with type narrowing of `ConflictResolution` in `CloudSyncService`.
- Corrected the import of `ProductAnalytics` by exporting it from `AnalyticsService`.
- Fixed incorrect imports of `storageService`.
- Renamed calls from `addProduct` to the correct `createProduct` method.

I was in the process of fixing remaining service-layer errors. The next steps would have been to investigate and fix issues in `AuthService`, `DatabaseInitService`, `AnalyticsService`, `CloudNetworkService`, and `CloudSyncService`.